### PR TITLE
Changed PK in batch sessions

### DIFF
--- a/app/ALDActiveClientSession.Table.al
+++ b/app/ALDActiveClientSession.Table.al
@@ -10,9 +10,13 @@ table 55113 "ALD Active Client Session"
             TableRelation = "ALD Test Batch";
             Editable = false;
         }
-        field(20; "Session No."; Code[20])
+        field(15; "No."; Integer)
         {
-            Caption = 'Session No.';
+            Caption = 'No.';
+        }
+        field(20; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
             TableRelation = "ALD Batch Session"."Session Code" where("Batch Name" = field("Batch Name"));
             Editable = false;
         }
@@ -31,7 +35,7 @@ table 55113 "ALD Active Client Session"
 
     keys
     {
-        key(PK; "Batch Name", "Session No.", "Clone No.")
+        key(PK; "Batch Name", "No.", "Clone No.")
         {
             Clustered = true;
         }

--- a/app/ALDActiveSessionsSubpage.Page.al
+++ b/app/ALDActiveSessionsSubpage.Page.al
@@ -10,7 +10,7 @@ page 55107 "ALD Active Sessions Subpage"
         {
             repeater(SessionDetails)
             {
-                field(SessionNo; Rec."Session No.")
+                field(SessionCode; Rec."Session Code")
                 {
                     ApplicationArea = All;
                     ToolTip = 'Sequential number of the session in the batch.';

--- a/app/ALDActiveTaskError.Table.al
+++ b/app/ALDActiveTaskError.Table.al
@@ -11,32 +11,36 @@ table 55109 "ALD Active Task Error"
             Caption = 'Batch Name';
             TableRelation = "ALD Test Batch";
         }
-        field(3; "Session No."; Code[20])
+        field(3; "No."; Integer)
         {
-            Caption = 'Session No.';
-            TableRelation = "ALD Active Test Session"."Session No." where("Batch Name" = field("Batch Name"));
+            Caption = 'No.';
         }
-        field(4; "Session Clone No."; Integer)
+        field(4; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
+            TableRelation = "ALD Active Test Session"."Session Code" where("Batch Name" = field("Batch Name"));
+        }
+        field(5; "Session Clone No."; Integer)
         {
             Caption = 'Session Clone No.';
-            TableRelation = "ALD Active Test Session"."Clone No." where("Batch Name" = field("Batch Name"), "Session No." = field("Session No."));
+            TableRelation = "ALD Active Test Session"."Clone No." where("Batch Name" = field("Batch Name"), "No." = field("No."));
         }
-        field(5; "Task No."; Code[20])
+        field(6; "Task No."; Code[20])
         {
             Caption = 'Task No.';
             TableRelation =
                 "ALD Active Test Task"."Task No." where("Batch Name" = field("Batch Name"),
-                "Session No." = field("Session No."), "Session Clone No." = field("Session Clone No."));
+                "No." = field("No."), "Session Clone No." = field("Session Clone No."));
         }
-        field(6; "Error Code"; Text[30])
+        field(7; "Error Code"; Text[30])
         {
             Caption = 'Error Code';
         }
-        field(7; "Error Text"; Blob)
+        field(8; "Error Text"; Blob)
         {
             Caption = 'Error Text';
         }
-        field(8; "Error Call Stack"; Blob)
+        field(9; "Error Call Stack"; Blob)
         {
             Caption = 'Error Call Stack';
         }
@@ -44,7 +48,7 @@ table 55109 "ALD Active Task Error"
 
     keys
     {
-        key(PK; "Batch Name", "Session No.", "Session Clone No.", "Task No.")
+        key(PK; "Batch Name", "No.", "Session Clone No.", "Task No.")
         {
             Clustered = true;
         }

--- a/app/ALDActiveTestBatch.Page.al
+++ b/app/ALDActiveTestBatch.Page.al
@@ -46,7 +46,8 @@ page 55106 "ALD Active Test Batch"
             part(ActiveTestTasks; "ALD Active Tasks Subpage")
             {
                 Provider = ActiveTestSessions;
-                SubPageLink = "Batch Name" = field("Batch Name"), "Session No." = field("Session No."), "Session Clone No." = field("Clone No.");
+                SubPageLink =
+                    "Batch Name" = field("Batch Name"), "No." = field("No."), "Session Clone No." = field("Clone No.");
                 ApplicationArea = All;
             }
 
@@ -77,7 +78,7 @@ page 55106 "ALD Active Test Batch"
                 ApplicationArea = All;
                 Provider = ActiveTestTasks;
                 SubPageLink =
-                    "Batch Name" = field("Batch Name"), "Session No." = field("Session No."),
+                    "Batch Name" = field("Batch Name"), "No." = field("No."),
                     "Session Clone No." = field("Session Clone No."), "Task No." = field("Task No.");
             }
         }

--- a/app/ALDActiveTestSession.Table.al
+++ b/app/ALDActiveTestSession.Table.al
@@ -11,9 +11,13 @@ table 55106 "ALD Active Test Session"
             Caption = 'Batch Name';
             TableRelation = "ALD Test Batch";
         }
-        field(20; "Session No."; Code[20])
+        field(15; "No."; Integer)
         {
-            Caption = 'Session No.';
+            Caption = 'No.';
+        }
+        field(20; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
             TableRelation = "ALD Batch Session"."Session Code" where("Batch Name" = field("Batch Name"));
         }
         field(30; "Clone No."; Integer)
@@ -26,7 +30,7 @@ table 55106 "ALD Active Test Session"
             Editable = false;
             FieldClass = FlowField;
             CalcFormula = lookup("ALD Active Client Session"."Client Session ID"
-                where("Batch Name" = field("Batch Name"), "Session No." = field("Session No."), "Clone No." = field("Clone No.")));
+                where("Batch Name" = field("Batch Name"), "Session Code" = field("Session Code"), "Clone No." = field("Clone No.")));
         }
         field(50; "Scheduled Start DateTime"; DateTime)
         {
@@ -65,7 +69,7 @@ table 55106 "ALD Active Test Session"
 
     keys
     {
-        key(PK; "Batch Name", "Session No.", "Clone No.")
+        key(PK; "Batch Name", "No.", "Clone No.")
         {
             Clustered = true;
         }
@@ -77,12 +81,12 @@ table 55106 "ALD Active Test Session"
         ActiveTaskError: Record "ALD Active Task Error";
     begin
         ActiveTestTask.SetRange("Batch Name", Rec."Batch Name");
-        ActiveTestTask.SetRange("Session No.", Rec."Session No.");
+        ActiveTestTask.SetRange("Session Code", Rec."Session Code");
         ActiveTestTask.SetRange("Session Clone No.", Rec."Clone No.");
         ActiveTestTask.DeleteAll(true);
 
         ActiveTaskError.SetRange("Batch Name", Rec."Batch Name");
-        ActiveTaskError.SetRange("Session No.", Rec."Session No.");
+        ActiveTaskError.SetRange("Session Code", Rec."Session Code");
         ActiveTaskError.SetRange("Session Clone No.", Rec."Clone No.");
         ActiveTaskError.DeleteAll(true);
     end;

--- a/app/ALDActiveTestTask.Table.al
+++ b/app/ALDActiveTestTask.Table.al
@@ -12,22 +12,28 @@ table 55108 "ALD Active Test Task"
             TableRelation = "ALD Active Test Batch";
             Editable = false;
         }
-        field(20; "Session No."; Code[20])
+        field(15; "No."; Integer)
         {
-            Caption = 'Session No.';
-            TableRelation = "ALD Active Test Session"."Session No." where("Batch Name" = field("Batch Name"));
+            Caption = 'No.';
+        }
+        field(20; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
+            TableRelation = "ALD Active Test Session"."Session Code" where("Batch Name" = field("Batch Name"));
             Editable = false;
         }
         field(30; "Session Clone No."; Integer)
         {
             Caption = 'Session Clone No.';
-            TableRelation = "ALD Active Test Session"."Clone No." where("Batch Name" = field("Batch Name"), "Session No." = field("Session No."));
+            TableRelation =
+                "ALD Active Test Session"."Clone No."
+                    where("Batch Name" = field("Batch Name"), "No." = field("No."));
             Editable = false;
         }
         field(40; "Task No."; Code[20])
         {
             Caption = 'Task No.';
-            TableRelation = "ALD Test Task"."Task No." where("Session Code" = field("Session No."));
+            TableRelation = "ALD Test Task"."Task No." where("Session Code" = field("Session Code"));
             Editable = false;
         }
         field(50; State; Enum "ALD Test State")
@@ -87,7 +93,7 @@ table 55108 "ALD Active Test Task"
 
     keys
     {
-        key(PK; "Batch Name", "Session No.", "Session Clone No.", "Task No.")
+        key(PK; "Batch Name", "No.", "Session Clone No.", "Task No.")
         {
             Clustered = true;
         }

--- a/app/ALDBatchSessions.Page.al
+++ b/app/ALDBatchSessions.Page.al
@@ -3,8 +3,6 @@ page 55102 "ALD Batch Sessions"
     PageType = List;
     SourceTable = "ALD Batch Session";
     Caption = 'Batch Sessions';
-    UsageCategory = Lists;
-    ApplicationArea = All;
 
     layout
     {
@@ -14,7 +12,7 @@ page 55102 "ALD Batch Sessions"
             {
                 Caption = 'Test Sessions';
 
-                field(SequenceNo; Rec."Session Sequence No.")
+                field(No; Rec."No.")
                 {
                     ApplicationArea = All;
                     ToolTip = 'The sequential number of the session within the batch.';
@@ -54,4 +52,21 @@ page 55102 "ALD Batch Sessions"
             }
         }
     }
+
+    trigger OnNewRecord(BelowxRec: Boolean)
+    var
+        BatchSession: Record "ALD Batch Session";
+    begin
+        "Sequence No." := xRec."Sequence No." + 1;
+        if not BelowxRec then begin
+            BatchSession.SetRange("Batch Name", Rec."Batch Name");
+            BatchSession.SetFilter("Sequence No.", '>%1', xRec."Sequence No.");
+            BatchSession.Ascending(false);
+            BatchSession.FindSet(true);
+            repeat
+                BatchSession."Sequence No." += 1;
+                BatchSession.Modify(true);
+            until BatchSession.Next() = 0;
+        end;
+    end;
 }

--- a/app/ALDCompletedSessionsSubpage.Page.al
+++ b/app/ALDCompletedSessionsSubpage.Page.al
@@ -10,7 +10,7 @@ page 55111 "ALD Completed Sessions Subpage"
         {
             repeater(SessionDetails)
             {
-                field(SessionNo; Rec."Session No.")
+                field(SessionNo; Rec."Session Code")
                 {
                     ApplicationArea = All;
                     ToolTip = 'Sequential number of the session in the batch.';

--- a/app/ALDCompletedTaskError.Table.al
+++ b/app/ALDCompletedTaskError.Table.al
@@ -16,32 +16,38 @@ table 55114 "ALD Completed Task Error"
             Caption = 'Batch Name';
             TableRelation = "ALD Test Batch";
         }
-        field(3; "Session No."; Code[20])
+        field(3; "No."; Integer)
         {
-            Caption = 'Session No.';
-            TableRelation = "ALD Completed Test Session"."Session No." where("Test Batch Name" = field("Batch Name"));
+            Caption = 'No.';
         }
-        field(4; "Session Clone No."; Integer)
+        field(4; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
+            TableRelation = "ALD Completed Test Session"."Session Code" where("Test Batch Name" = field("Batch Name"));
+        }
+        field(5; "Session Clone No."; Integer)
         {
             Caption = 'Session Clone No.';
-            TableRelation = "ALD Completed Test Session"."Clone No." where("Test Batch Name" = field("Batch Name"), "Session No." = field("Session No."));
+            TableRelation =
+                "ALD Completed Test Session"."Clone No."
+                    where("Test Batch Name" = field("Batch Name"), "No." = field("No."));
         }
-        field(5; "Task No."; Code[20])
+        field(6; "Task No."; Code[20])
         {
             Caption = 'Task No.';
             TableRelation =
                 "ALD Completed Test Task"."Task No." where("Batch Name" = field("Batch Name"),
-                "Session No." = field("Session No."), "Session Clone No." = field("Session Clone No."));
+                "No." = field("No."), "Session Clone No." = field("Session Clone No."));
         }
-        field(6; "Error Code"; Text[30])
+        field(7; "Error Code"; Text[30])
         {
             Caption = 'Error Code';
         }
-        field(7; "Error Text"; Blob)
+        field(8; "Error Text"; Blob)
         {
             Caption = 'Error Text';
         }
-        field(8; "Error Call Stack"; Blob)
+        field(9; "Error Call Stack"; Blob)
         {
             Caption = 'Error Call Stack';
         }
@@ -49,7 +55,7 @@ table 55114 "ALD Completed Task Error"
 
     keys
     {
-        key(PK; "Test Run No.", "Session No.", "Session Clone No.", "Task No.")
+        key(PK; "Test Run No.", "No.", "Session Clone No.", "Task No.")
         {
             Clustered = true;
         }

--- a/app/ALDCompletedTestBatchCard.Page.al
+++ b/app/ALDCompletedTestBatchCard.Page.al
@@ -4,6 +4,7 @@ page 55113 "ALD Completed Test Batch Card"
     SourceTable = "ALD Completed Test Batch";
     Caption = 'Completed Load Test Batch';
     Editable = false;
+    DataCaptionFields = "Test Run No.", "Test Batch Name";
 
     layout
     {
@@ -46,7 +47,7 @@ page 55113 "ALD Completed Test Batch Card"
                 Provider = TestSessions;
                 SubPageLink =
                     "Test Run No." = field("Test Run No."), "Batch Name" = field("Test Batch Name"),
-                    "Session No." = field("Session No."), "Session Clone No." = field("Clone No.");
+                    "No." = field("No."), "Session Clone No." = field("Clone No.");
 
                 ApplicationArea = All;
             }

--- a/app/ALDCompletedTestBatchList.Page.al
+++ b/app/ALDCompletedTestBatchList.Page.al
@@ -25,6 +25,11 @@ page 55110 "ALD Completed Test Batch List"
                 {
                     ApplicationArea = All;
                     ToolTip = 'The name of the test batch.';
+
+                    trigger OnDrillDown()
+                    begin
+                        Page.Run(Page::"ALD Completed Test Batch Card", Rec);
+                    end;
                 }
                 field("Start DateTime"; "Start DateTime")
                 {

--- a/app/ALDCompletedTestSession.Table.al
+++ b/app/ALDCompletedTestSession.Table.al
@@ -15,9 +15,13 @@ table 55111 "ALD Completed Test Session"
             Caption = 'Test Batch No.';
             TableRelation = "ALD Completed Test Batch"."Test Batch Name" where("Test Run No." = field("Test Run No."));
         }
-        field(20; "Session No."; Code[20])
+        field(15; "No."; Integer)
         {
-            Caption = 'Session No.';
+            Caption = 'No.';
+        }
+        field(20; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
             TableRelation = "ALD Batch Session"."Session Code" where("Batch Name" = field("Test Batch Name"));
         }
         field(30; "Clone No."; Integer)
@@ -49,11 +53,11 @@ table 55111 "ALD Completed Test Session"
 
     keys
     {
-        key(PK; "Test Run No.", "Session No.", "Clone No.")
+        key(PK; "Test Run No.", "No.", "Clone No.")
         {
             Clustered = true;
         }
-        key(BatchSession; "Test Batch Name", "Session No.", "Clone No.") { }
+        key(BatchSession; "Test Batch Name") { }
         key(RunDateTime; "Start DateTime", "End DateTime") { }
     }
 }

--- a/app/ALDCompletedTestTask.Table.al
+++ b/app/ALDCompletedTestTask.Table.al
@@ -15,10 +15,14 @@ table 55112 "ALD Completed Test Task"
             Caption = 'Test Batch Name';
             TableRelation = "ALD Completed Test Batch"."Test Batch Name" where("Test Run No." = field("Test Run No."));
         }
-        field(20; "Session No."; Code[20])
+        field(15; "No."; Integer)
         {
-            Caption = 'Session No.';
-            TableRelation = "ALD Completed Test Session"."Session No." where("Test Run No." = field("Test Run No."));
+            Caption = 'No.';
+        }
+        field(20; "Session Code"; Code[20])
+        {
+            Caption = 'Session Code';
+            TableRelation = "ALD Completed Test Session"."Session Code" where("Test Run No." = field("Test Run No."));
         }
         field(30; "Session Clone No."; Integer)
         {
@@ -28,7 +32,7 @@ table 55112 "ALD Completed Test Task"
         field(40; "Task No."; Code[20])
         {
             Caption = 'Task No.';
-            TableRelation = "ALD Test Task"."Task No." where("Session Code" = field("Session No."));
+            TableRelation = "ALD Test Task"."Task No." where("Session Code" = field("Session Code"));
         }
         field(50; State; Enum "ALD Completed Test State")
         {
@@ -73,11 +77,11 @@ table 55112 "ALD Completed Test Task"
 
     keys
     {
-        key(PK; "Test Run No.", "Session No.", "Session Clone No.", "Task No.")
+        key(PK; "Test Run No.", "No.", "Session Clone No.", "Task No.")
         {
             Clustered = true;
         }
-        key(BatchTask; "Batch Name", "Session No.", "Session Clone No.", "Task No.") { }
+        key(BatchTask; "Batch Name") { }
         key(RunDateTime; "Start DateTime", "End DateTime") { }
     }
 }

--- a/app/ALDSessionController.Codeunit.al
+++ b/app/ALDSessionController.Codeunit.al
@@ -55,7 +55,7 @@ codeunit 55104 "ALD Session Controller"
     begin
         ActiveTestTask.LockTable();
         ActiveTestTask.SetRange("Batch Name", CompletedTestSession."Test Batch Name");
-        ActiveTestTask.SetRange("Session No.", CompletedTestSession."Session No.");
+        ActiveTestTask.SetRange("Session Code", CompletedTestSession."Session Code");
         ActiveTestTask.SetRange("Session Clone No.", CompletedTestSession."Clone No.");
         if ActiveTestTask.FindSet(true) then
             repeat
@@ -73,7 +73,7 @@ codeunit 55104 "ALD Session Controller"
         CompletedTaskError: Record "ALD Completed Task Error";
     begin
         ActiveTaskError.SetRange("Batch Name", CompletedTestTask."Batch Name");
-        ActiveTaskError.SetRange("Session No.", CompletedTestTask."Session No.");
+        ActiveTaskError.SetRange("No.", CompletedTestTask."No.");
         ActiveTaskError.SetRange("Session Clone No.", CompletedTestTask."Session Clone No.");
         ActiveTaskError.SetRange("Task No.", CompletedTestTask."Task No.");
         if ActiveTaskError.FindSet() then
@@ -122,7 +122,7 @@ codeunit 55104 "ALD Session Controller"
 
         if StartSession(SessionId, Codeunit::"ALD Session Task Controller", SessionCompanyName, ActiveTestSession) then begin
             ActiveClientSession.Validate("Batch Name", ActiveTestSession."Batch Name");
-            ActiveClientSession.Validate("Session No.", ActiveTestSession."Session No.");
+            ActiveClientSession.Validate("No.", ActiveTestSession."No.");
             ActiveClientSession.Validate("Clone No.", ActiveTestSession."Clone No.");
             ActiveClientSession.Validate("Client Session ID", SessionId);
             ActiveClientSession.Insert(true);
@@ -170,7 +170,7 @@ codeunit 55104 "ALD Session Controller"
     begin
         ActiveTestTask.SetRange(State, ActiveTestTask.State::Running);
         ActiveTestTask.SetRange("Batch Name", ActiveTestSession."Batch Name");
-        ActiveTestTask.SetRange("Session No.", ActiveTestSession."Session No.");
+        ActiveTestTask.SetRange("Session Code", ActiveTestSession."Session Code");
         ActiveTestTask.SetRange("Session Clone No.", ActiveTestSession."Clone No.");
 
         if ActiveTestTask.FindFirst() then begin

--- a/app/ALDSessionTaskController.Codeunit.al
+++ b/app/ALDSessionTaskController.Codeunit.al
@@ -17,7 +17,7 @@ codeunit 55102 "ALD Session Task Controller"
         SetSessionRunningState(ActiveTestSession);
 
         IsSessionSuccessful := true;
-        ActiveTestTask.SetRange("Session No.", ActiveTestSession."Session No.");
+        ActiveTestTask.SetRange("Session Code", ActiveTestSession."Session Code");
         ActiveTestTask.SetRange("Session Clone No.", ActiveTestSession."Clone No.");
         if ActiveTestTask.FindSet() then
             repeat
@@ -83,7 +83,7 @@ codeunit 55102 "ALD Session Task Controller"
         BlobOutStream: OutStream;
     begin
         ActiveTaskError.Validate("Batch Name", ActiveTestTask."Batch Name");
-        ActiveTaskError.Validate("Session No.", ActiveTestTask."Session No.");
+        ActiveTaskError.Validate("Session Code", ActiveTestTask."Session Code");
         ActiveTaskError.Validate("Session Clone No.", ActiveTestTask."Session Clone No.");
         ActiveTaskError.Validate("Task No.", ActiveTestTask."Task No.");
         ActiveTaskError.Validate("Error Code", CopyStr(GetLastErrorCode(), 1, MaxStrLen(ActiveTaskError."Error Code")));

--- a/app/ALDTestExecute.Codeunit.al
+++ b/app/ALDTestExecute.Codeunit.al
@@ -48,7 +48,7 @@ codeunit 55100 "ALD Test - Execute"
 
         for CloneCount := 1 to BatchSession."No. of Clones" do begin
             ActiveTestSession.Validate("Batch Name", BatchSession."Batch Name");
-            ActiveTestSession.Validate("Session No.", BatchSession."Session Code");
+            ActiveTestSession.Validate("Session Code", BatchSession."Session Code");
             ActiveTestSession.Validate("Clone No.", CloneCount);
             ActiveTestSession.Validate("Company Name", BatchSession."Company Name");
             ActiveTestSession.Validate(
@@ -65,11 +65,11 @@ codeunit 55100 "ALD Test - Execute"
         TestTask: Record "ALD Test Task";
         ActiveTestTask: Record "ALD Active Test Task";
     begin
-        TestTask.SetRange("Session Code", LoadTestActiveSession."Session No.");
+        TestTask.SetRange("Session Code", LoadTestActiveSession."Session Code");
         if TestTask.FindSet() then
             repeat
                 ActiveTestTask.Validate("Batch Name", LoadTestActiveSession."Batch Name");
-                ActiveTestTask.Validate("Session No.", LoadTestActiveSession."Session No.");
+                ActiveTestTask.Validate("Session Code", LoadTestActiveSession."Session Code");
                 ActiveTestTask.Validate("Session Clone No.", LoadTestActiveSession."Clone No.");
                 ActiveTestTask.Validate("Task No.", TestTask."Task No.");
                 ActiveTestTask.Validate("Object Type", TestTask."Object Type");

--- a/app/ALDTestSession.Table.al
+++ b/app/ALDTestSession.Table.al
@@ -7,7 +7,7 @@ table 55101 "ALD Test Session"
     {
         field(1; "Code"; Code[20])
         {
-            Caption = 'No.';
+            Caption = 'Code';
         }
         field(2; Description; Text[50])
         {

--- a/app/ALDTestTask.Table.al
+++ b/app/ALDTestTask.Table.al
@@ -7,7 +7,7 @@ table 55107 "ALD Test Task"
     {
         field(1; "Session Code"; Code[20])
         {
-            Caption = 'Session No.';
+            Caption = 'Session Code';
             TableRelation = "ALD Test Session";
             DataClassification = CustomerContent;
         }


### PR DESCRIPTION
Changed session numbering: added sequence number, which is included in the primary key for batch sessions. "Session No." renamed to "Session Code" and removed from PK because the same preconfigured session can be included in one batch multiple times.