### PR TITLE
Resolve task status update conflict

### DIFF
--- a/app/ALDSessionController.Codeunit.al
+++ b/app/ALDSessionController.Codeunit.al
@@ -140,6 +140,7 @@ codeunit 55104 "ALD Session Controller"
         ActiveTestSession: Record "ALD Active Test Session";
         ActiveTestBatch: Record "ALD Active Test Batch";
     begin
+        ActiveTestSession.SetFilter(State, '%1|%2', ActiveTestSession.State::Ready, ActiveTestSession.State::Running);
         if ActiveTestSession.FindSet() then
             repeat
                 TerminateTestSession(ActiveTestSession);

--- a/app/ALDSessionTaskController.Codeunit.al
+++ b/app/ALDSessionTaskController.Codeunit.al
@@ -17,7 +17,8 @@ codeunit 55102 "ALD Session Task Controller"
         SetSessionRunningState(ActiveTestSession);
 
         IsSessionSuccessful := true;
-        ActiveTestTask.SetRange("Session Code", ActiveTestSession."Session Code");
+        ActiveTestTask.SetRange("Batch Name", ActiveTestSession."Batch Name");
+        ActiveTestTask.SetRange("No.", ActiveTestSession."No.");
         ActiveTestTask.SetRange("Session Clone No.", ActiveTestSession."Clone No.");
         if ActiveTestTask.FindSet() then
             repeat


### PR DESCRIPTION
Bug: Sessions updating tasks running in a parallel session, which causes a stale record exception.
Fix: Apply correct session filters on active tasks to make sure that each session updates only tasks running in the same session. 